### PR TITLE
Horizontal tmuxinator bug

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -5,17 +5,17 @@ root: .
 
 windows:
   - thesis:
-      layout: main-vertical
+      layout: even-horizontal
       panes:
         -
         -
   - code:
-      layout: main-vertical
+      layout: even-horizontal
       panes:
         -
         -
   - evaluation:
-      layout: main-vertical
+      layout: even-horizontal
       panes:
         -
         -


### PR DESCRIPTION
Fix an error in `.tmuxinator.yml` in which I'd specified the wrong
division type of the window.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>