### PR TITLE
Record traffic method

### DIFF
--- a/evaluation/test-server/pkg/database/influx.go
+++ b/evaluation/test-server/pkg/database/influx.go
@@ -8,7 +8,7 @@ import (
 
 // WriteMetrics is called from a handler to write the eru and qos metrics to the
 // influxdb database.
-func WriteMetrics(eru, qos float64) error {
+func WriteMetrics(eru, qos float64, trafficPattern string) error {
 	influxClient, err := createClient()
 
 	if err != nil {
@@ -27,8 +27,9 @@ func WriteMetrics(eru, qos float64) error {
 
 	tags := map[string]string{"scaling-method": scalingMethod}
 	fields := map[string]interface{}{
-		"eru": eru,
-		"qos": qos,
+		"eru":             eru,
+		"qos":             qos,
+		"traffic-pattern": trafficPattern,
 	}
 
 	pt, err := client.NewPoint(PointName, tags, fields, time.Now())

--- a/evaluation/test-server/pkg/database/influx_test.go
+++ b/evaluation/test-server/pkg/database/influx_test.go
@@ -14,8 +14,8 @@ func TestWriteMetrics(t *testing.T) {
 
 	origCount := len(origQuery)
 
-	eru, qos := 1.0, 1.0
-	err = database.WriteMetrics(eru, qos)
+	eru, qos, trafficPattern := 1.0, 1.0, "increase-decrease"
+	err = database.WriteMetrics(eru, qos, trafficPattern)
 
 	if err != nil {
 		t.Fatal("Error writing metrics to the database.")

--- a/evaluation/test-server/pkg/handlers/load.go
+++ b/evaluation/test-server/pkg/handlers/load.go
@@ -26,6 +26,11 @@ const (
 	// EnvProduction is the value for the os environment variable
 	// `TEST_SERVER_ENV` if running production mode.
 	EnvProduction = "PRODUCTION"
+
+	// TrafficPatternParam is the parameter
+	// `?traffic-pattern=increase-decrease` identifying the Traffic Pattern
+	// being used for this evaluation.
+	TrafficPatternParam = "traffic-pattern"
 )
 
 // LoadHandler is the handler for the request to "/". It is to this api endpoint
@@ -40,7 +45,8 @@ func LoadHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		handleError(err, w, r)
 	} else {
-		err = database.WriteMetrics(eru, qos)
+		trafficPattern := r.URL.Query().Get(TrafficPatternParam)
+		err = database.WriteMetrics(eru, qos, trafficPattern)
 
 		if err != nil {
 			handleError(err, w, r)
@@ -48,9 +54,10 @@ func LoadHandler(w http.ResponseWriter, r *http.Request) {
 			// Output the response as JSON.
 			w.WriteHeader(200)
 
-			enc, err := json.Marshal(map[string]float64{
-				"eru": eru,
-				"qos": qos,
+			enc, err := json.Marshal(map[string]interface{}{
+				"eru":             eru,
+				"qos":             qos,
+				"traffic-pattern": trafficPattern,
 			})
 
 			if err == nil {

--- a/evaluation/test-server/pkg/handlers/load_test.go
+++ b/evaluation/test-server/pkg/handlers/load_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func TestLoad(t *testing.T) {
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/", testServer.URL), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/?traffic-pattern=increase-decrease",
+		testServer.URL), nil)
 	res, err := http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/evaluation/traffic/test-plans/increase-decrease-test-plan.jmx
+++ b/evaluation/traffic/test-plans/increase-decrease-test-plan.jmx
@@ -13,7 +13,7 @@
     <hashTree>
       <kg.apc.jmeter.threads.UltimateThreadGroup guiclass="kg.apc.jmeter.threads.UltimateThreadGroupGui" testclass="kg.apc.jmeter.threads.UltimateThreadGroup" testname="jp@gc - Ultimate Thread Group" enabled="true">
         <collectionProp name="ultimatethreadgroupdata">
-          <collectionProp name="-1006331772">
+          <collectionProp name="-1450167844">
             <stringProp name="1507423">1000</stringProp>
             <stringProp name="0">0</stringProp>
             <stringProp name="48">0</stringProp>
@@ -52,7 +52,7 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/</stringProp>
+          <stringProp name="HTTPSampler.path">/?traffic-pattern=increase-decrease</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>

--- a/evaluation/traffic/test-plans/sample-test-plan.jmx
+++ b/evaluation/traffic/test-plans/sample-test-plan.jmx
@@ -52,7 +52,7 @@
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
           <stringProp name="HTTPSampler.protocol"></stringProp>
           <stringProp name="HTTPSampler.contentEncoding"></stringProp>
-          <stringProp name="HTTPSampler.path">/</stringProp>
+          <stringProp name="HTTPSampler.path">/?traffic-pattern=sample-test-plan</stringProp>
           <stringProp name="HTTPSampler.method">GET</stringProp>
           <boolProp name="HTTPSampler.follow_redirects">true</boolProp>
           <boolProp name="HTTPSampler.auto_redirects">false</boolProp>


### PR DESCRIPTION
Fix #59 

Have `test-server` record the traffic-method that is receiving requests
from using URL params.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>