### PR TITLE
InfluxDB slight modification

### DIFF
--- a/evaluation/test-server/pkg/database/influx.go
+++ b/evaluation/test-server/pkg/database/influx.go
@@ -25,11 +25,13 @@ func WriteMetrics(eru, qos float64, trafficPattern string) error {
 		Precision: "s",
 	})
 
-	tags := map[string]string{"scaling-method": scalingMethod}
-	fields := map[string]interface{}{
-		"eru":             eru,
-		"qos":             qos,
+	tags := map[string]string{
+		"scaling-method":  scalingMethod,
 		"traffic-pattern": trafficPattern,
+	}
+	fields := map[string]interface{}{
+		"eru": eru,
+		"qos": qos,
 	}
 
 	pt, err := client.NewPoint(PointName, tags, fields, time.Now())


### PR DESCRIPTION
Instead of recording the traffic-pattern as a field variable, make it a
tag on the data, which will be easier to search for and just makes more
sense conceptually.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>