### PR TITLE
Add versioning to trials

### DIFF
--- a/evaluation/Makefile
+++ b/evaluation/Makefile
@@ -8,7 +8,7 @@
 # and `traffic`directories. A couple of environment variables must be set, as
 # can be seen in the example below.
 #
-# @EXAMPLE: export TS_RC=test-server-controller-reactive-5s.yaml; export TG_RC=traffic-generator-controller-increase-decrease-test-plan.yaml; export HPA=TRUE; export PREDICTIVE=TRUE; make test_start
+# @EXAMPLE: export TS_RC=test-server-controller-reactive-5s-v1.yaml; export TG_RC=traffic-generator-controller-increase-decrease-test-plan.yaml; export HPA=TRUE; export PREDICTIVE=TRUE; make test_start
 # @TODO Be sure to set HPA/PREDICTIVE to FALSE if we don't want to use them,
 # because otherwise the values will carry over.
 test_start:

--- a/evaluation/process/Makefile
+++ b/evaluation/process/Makefile
@@ -13,11 +13,13 @@ test:
 # Process the results of an evaluation test and output the results into the
 # `output` dir. The pod intitialization time is specified by $PIT and the traffic
 # pattern is specified by $TP. The output dir to write to is specified by $OUT.
+# The version, [v1|v2...], is specified by `VERSION`.
 #
-# @example `export PIT=5s; export TP=increase-decrease; export OUT=/code/output; make
-# process`.
+# @TODO `VERSION` must be specified.
+#
+# @example `export PIT=5s; export TP=increase-decrease; export VERSION=v2; export OUT=/code/output; make process`.
 process:
-	docker run --rm --env-file=.env -i -v $(shell pwd):/code mattjmcnaughton/thesis-python:latest python /code/evaluate.py $(PIT) $(TP) $(OUT)
+	docker run --rm --env-file=.env -i -v $(shell pwd):/code mattjmcnaughton/thesis-python:latest python /code/evaluate.py $(PIT) $(TP) $(VERSION) $(OUT)
 
 # `make backup`
 #

--- a/evaluation/process/test_evaluate.py
+++ b/evaluation/process/test_evaluate.py
@@ -69,10 +69,11 @@ class EvaluateTestCase(unittest.TestCase):
     runs methods contained with the `Evaluate` class.
     """
 
-    # PIT and TP are the pod initialization time and test pattern that we mock
-    # for.
+    # PIT, TP, VERSION are the pod initialization time, test pattern, and
+    # version that we mock for.
     PIT = "5s"
     TP = "increase-decrease"
+    VERSION = "v2"
 
     def __init__(self, *args, **kwargs):
         super(EvaluateTestCase, self).__init__(*args, **kwargs)
@@ -251,7 +252,7 @@ class EvaluateTestCase(unittest.TestCase):
         Returns:
             Evaluate: An instance of the Evaluate class.
         """
-        evaluate = Evaluate(self.PIT, self.TP, self._get_tmp_dir())
+        evaluate = Evaluate(self.PIT, self.TP, self.VERSION, self._get_tmp_dir())
 
         evaluate.query_influx = MagicMock()
         evaluate.query_influx = InfluxDBMock.query_influx

--- a/evaluation/test-server/.env.development
+++ b/evaluation/test-server/.env.development
@@ -14,5 +14,8 @@ SCALING_METHOD=DEVELOPMENT
 # Take five seconds to initialize the container within the pod.
 INITIALIZATION_TIME=5s
 
+# If no version is specified, use version 1.
+VERSION=v1
+
 # The operating environment (i.e. DEVELOPMENT, PRODUCTION...)
 TEST_SERVER_ENV=DEVELOPMENT

--- a/evaluation/test-server/config/config.json
+++ b/evaluation/test-server/config/config.json
@@ -1,4 +1,5 @@
 {
   "autoscaling_methods": ["static-average", "reactive", "predictive"],
-  "pod_initialization_times": ["5s", "135s"]
+  "pod_initialization_times": ["5s", "135s"],
+  "versions": ["v1", "v2"]
 }

--- a/evaluation/test-server/config/sample-test-server-controller.yaml.jinja
+++ b/evaluation/test-server/config/sample-test-server-controller.yaml.jinja
@@ -47,6 +47,8 @@ spec:
           value: {{ autoscaling_method }}
         - name: INITIALIZATION_TIME
           value: {{ pod_initialization_time }}
+        - name: VERSION
+          value: {{ version }}
         # The following variables are all stored in `secret-config.json` and
         # should be kept secret - hence the `generated/` dir is not checked into
         # version control.

--- a/evaluation/test-server/docs/trial-versioning.md
+++ b/evaluation/test-server/docs/trial-versioning.md
@@ -1,0 +1,25 @@
+# Trail Versioning
+
+We ran multiple versions of our trials within different parameters for
+predictive auto-scaling and Kubernetes.
+
+- v1/unlabelled - This is the trial reflecting a standard Kubernetes deploy,
+  with out addition of predictive auto-scaling. If a data point does not have a
+  version attached, we assume it is part of v1.
+- v2 - This is the trial in which we change the upscaleForbiddenWindow to `30
+  seconds` instead of `3 minutes`.
+- v3 - This is the trial in which we downscale predictively based on the 30
+  second grace period, in addition to the `v2` changes.
+
+## Specifying trial version when running trials
+
+We will create configuration files for `test-server` which include the `VERSION`
+env variable. So to run v2 trials with a 135s pod initialization time, run
+`export TS_RC=test-server-controller-reactive-5s-v2.yaml; export ...; make run`.
+Make sure that the appropriate version of the Kubernetes cluster is running.
+
+## Specifying trial version when performing post-processing
+
+We'll pass the version to `evaluate.py` as a command line argument. We'll use an
+environment variable in our make task to specify the version, so run `export
+PIT=5s; export TP=increase-decrease; export VERSION=v2; export OUT=/code/output; make process`

--- a/evaluation/test-server/pkg/database/influx.go
+++ b/evaluation/test-server/pkg/database/influx.go
@@ -29,6 +29,7 @@ func WriteMetrics(eru, qos float64, trafficPattern string) error {
 		"sm":  scalingMethod,
 		"tp":  trafficPattern,
 		"pit": podInitializationTime,
+		"ver": version,
 	}
 	fields := map[string]interface{}{
 		"eru": eru,

--- a/evaluation/test-server/pkg/database/influx_test.go
+++ b/evaluation/test-server/pkg/database/influx_test.go
@@ -2,9 +2,11 @@ package database_test
 
 import (
 	"github.com/mattjmcnaughton/test-server/pkg/database"
+	"os"
 	"testing"
 )
 
+// TestWriteMetrics confirms we are writing metrics to the database correctly.
 func TestWriteMetrics(t *testing.T) {
 	origQuery, err := database.QueryDatabase()
 
@@ -14,12 +16,7 @@ func TestWriteMetrics(t *testing.T) {
 
 	origCount := len(origQuery)
 
-	eru, qos, trafficPattern := 1.0, 1.0, "increase-decrease"
-	err = database.WriteMetrics(eru, qos, trafficPattern)
-
-	if err != nil {
-		t.Fatal("Error writing metrics to the database.")
-	}
+	writeToDatabase(t)
 
 	afterQuery, err := database.QueryDatabase()
 
@@ -32,5 +29,37 @@ func TestWriteMetrics(t *testing.T) {
 	if afterCount != origCount+1 {
 		t.Fatalf("Should add one new elem, instead of adding %v, %v exist",
 			afterCount-origCount, afterCount)
+	}
+}
+
+// TestProperTags confirms we are recording the tags correctly.
+func TestProperTags(t *testing.T) {
+	writeToDatabase(t)
+
+	afterQuery, err := database.QueryDatabase()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	lastEntry := afterQuery[len(afterQuery)-1]
+
+	found := false
+	for _, tag := range lastEntry {
+		if tag == os.Getenv("VERSION") {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Fatal("Should have found the VERSION tag.")
+	}
+}
+
+func writeToDatabase(t *testing.T) {
+	eru, qos, trafficPattern := 1.0, 1.0, "increase-decrease"
+	err := database.WriteMetrics(eru, qos, trafficPattern)
+
+	if err != nil {
+		t.Fatal("Error writing metrics to the database.")
 	}
 }

--- a/evaluation/test-server/pkg/database/utils.go
+++ b/evaluation/test-server/pkg/database/utils.go
@@ -20,9 +20,10 @@ var (
 	databaseUsername = os.Getenv("DATABASE_USERNAME")
 	databasePassword = os.Getenv("DATABASE_PASSWORD")
 
-	// The method of auto-scaling and pit in use for this container.
+	// The method of auto-scaling, pit, version in use for this container.
 	scalingMethod         = os.Getenv("SCALING_METHOD")
 	podInitializationTime = os.Getenv("INITIALIZATION_TIME")
+	version               = os.Getenv("VERSION")
 )
 
 // createClient is an internal method for creating a HTTP Connection to the database.


### PR DESCRIPTION
Fix #95 

This commit adds configuration to `test-server` and `evaluate.py` so
that we can run multiple versions. However, it is important to note that
the `evaluate.py` will not work until an actual versioned trial is run,
so if any evaluations are necessary in the meantime, we will need to do
them with a previous git commit.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>